### PR TITLE
allow latest stable SymfonyConfigTest versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,21 +8,28 @@ php:
   - hhvm
 
 matrix:
+  include:
+    - php: 5.3
+      env: deps="low"
   allow_failures:
     - php: hhvm
 
 env:
-  - SYMFONY_VERSION=2.4.* PHPUNIT_VERSION=~3.7
-  - SYMFONY_VERSION=2.0.* PHPUNIT_VERSION=~4.0
-  - SYMFONY_VERSION=2.1.* PHPUNIT_VERSION=~4.0
-  - SYMFONY_VERSION=2.2.* PHPUNIT_VERSION=~4.0
-  - SYMFONY_VERSION=2.3.* PHPUNIT_VERSION=~4.0
-  - SYMFONY_VERSION=2.4.* PHPUNIT_VERSION=~4.0
+  global:
+    - deps=""
+  matrix:
+    - SYMFONY_VERSION=2.4.* PHPUNIT_VERSION=~3.7
+    - SYMFONY_VERSION=2.0.* PHPUNIT_VERSION=~4.0
+    - SYMFONY_VERSION=2.1.* PHPUNIT_VERSION=~4.0
+    - SYMFONY_VERSION=2.2.* PHPUNIT_VERSION=~4.0
+    - SYMFONY_VERSION=2.3.* PHPUNIT_VERSION=~4.0
+    - SYMFONY_VERSION=2.4.* PHPUNIT_VERSION=~4.0
 
 before_script:
-  - composer require --no-update "symfony/dependency-injection:${SYMFONY_VERSION}"
-  - composer require --no-update "phpunit/phpunit:${PHPUNIT_VERSION}"
-  - composer update
+  - if [ "$SYMFONY_VERSION" != "" ]; then composer require --no-update "symfony/dependency-injection:${SYMFONY_VERSION}"; fi
+  - if [ "$PHPUNIT_VERSION" != "" ]; then composer require --no-update "phpunit/phpunit:${PHPUNIT_VERSION}"; fi
+  - if [ "$deps" = "low" ]; then composer update --prefer-lowest; fi
+  - if [ "$deps" = "" ]; then composer update; fi
 
 notifications:
   email: matthiasnoback@gmail.com

--- a/composer.json
+++ b/composer.json
@@ -13,8 +13,9 @@
         }
     ],
     "require": {
-        "matthiasnoback/symfony-config-test": "0.*",
-        "symfony/dependency-injection": "2.*",
+        "matthiasnoback/symfony-config-test": "0.*|~1.0",
+        "symfony/dependency-injection": "^2.0.5",
+        "symfony/config": "^2.0.5",
         "phpunit/phpunit": ">=3",
         "sebastian/exporter": "~1"
     },


### PR DESCRIPTION
This fixes #41. And additional Travis CI job was added (run builds with
the lowest allowed dependency versions) to ensure that the package still
works with `0.*` versions of the `matthiasnoback/symfony-config-test`
package.