### PR TITLE
Require phpunit on dev only

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,8 +16,10 @@
         "matthiasnoback/symfony-config-test": "0.*|~1.0",
         "symfony/dependency-injection": "^2.0.5",
         "symfony/config": "^2.0.5",
-        "phpunit/phpunit": ">=3",
         "sebastian/exporter": "~1"
+    },
+    "require-dev": {
+        "phpunit/phpunit": ">=3"
     },
     "autoload": {
         "psr-4" : { "Matthias\\SymfonyDependencyInjectionTest\\" : "" }


### PR DESCRIPTION
Like you did here: https://packagist.org/packages/matthiasnoback/symfony-config-test

Users does not necessary want to download all phpunit package and dependencies on they own projects.