### PR TITLE
[Travis] run build with PHP 7 instead of PHP 7.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ php:
   - 5.4
   - 5.5
   - 5.6
-  - nightly
+  - 7.0
   - hhvm
 
 matrix:


### PR DESCRIPTION
The `nightly` version on Travis now refers to the nightly dev builds of
PHP 7.1.