### PR TITLE
only use PHPUnit 3 and PHPUnit 4 in tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,6 +40,8 @@ before_script:
   - if [ "$deps" = "low" ]; then composer update --prefer-lowest; fi
   - if [ "$deps" = "" ]; then composer install; fi
 
+script: vendor/bin/phpunit
+
 notifications:
   email: matthiasnoback@gmail.com
 

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "sebastian/exporter": "~1"
     },
     "require-dev": {
-        "phpunit/phpunit": ">=3"
+        "phpunit/phpunit": "~3.0|~4.0"
     },
     "autoload": {
         "psr-4" : { "Matthias\\SymfonyDependencyInjectionTest\\" : "" }


### PR DESCRIPTION
Currently, the package isn't compatible with PHPUnit 5. This also means that tests on Travis CI must be performed using the PHPUnit version installed in the `vendor/` directory instead of using the one shipped with the Travis environment.
