### PR TITLE
use YAML parser compatible with the DI component

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,31 +16,32 @@ matrix:
     - php: 5.3
       env: deps="low"
     - php: 5.6
-      env: SYMFONY_VERSION=2.3.* PHPUNIT_VERSION=~3.7
+      env: SYMFONY_DI_VERSION=2.3.* PHPUNIT_VERSION=~3.7
     - php: 5.6
-      env: SYMFONY_VERSION=2.0.* PHPUNIT_VERSION=~4.0
+      env: SYMFONY_DI_VERSION=2.0.* SYMFONY_YAML_VERSION=2.7.* PHPUNIT_VERSION=~4.0
     - php: 5.6
-      env: SYMFONY_VERSION=2.1.* PHPUNIT_VERSION=~4.0
+      env: SYMFONY_DI_VERSION=2.1.* SYMFONY_YAML_VERSION=2.7.* PHPUNIT_VERSION=~4.0
     - php: 5.6
-      env: SYMFONY_VERSION=2.2.* PHPUNIT_VERSION=~4.0
+      env: SYMFONY_DI_VERSION=2.2.* SYMFONY_YAML_VERSION=2.7.* PHPUNIT_VERSION=~4.0
     - php: 5.6
-      env: SYMFONY_VERSION=2.3.* PHPUNIT_VERSION=~4.0
+      env: SYMFONY_DI_VERSION=2.3.* PHPUNIT_VERSION=~4.0
     - php: 5.6
-      env: SYMFONY_VERSION=2.4.* PHPUNIT_VERSION=~4.0
+      env: SYMFONY_DI_VERSION=2.4.* PHPUNIT_VERSION=~4.0
     - php: 5.6
-      env: SYMFONY_VERSION=2.6.* PHPUNIT_VERSION=~4.0
+      env: SYMFONY_DI_VERSION=2.6.* PHPUNIT_VERSION=~4.0
     - php: 5.6
-      env: SYMFONY_VERSION=2.7.* PHPUNIT_VERSION=~4.0
+      env: SYMFONY_DI_VERSION=2.7.* PHPUNIT_VERSION=~4.0
     - php: 5.6
-      env: SYMFONY_VERSION=2.8.* PHPUNIT_VERSION=~4.0
+      env: SYMFONY_DI_VERSION=2.8.* PHPUNIT_VERSION=~4.0
     - php: 5.6
-      env: SYMFONY_VERSION=3.0.* PHPUNIT_VERSION=~4.0
+      env: SYMFONY_DI_VERSION=3.0.* PHPUNIT_VERSION=~4.0
   allow_failures:
     - php: hhvm
 
 before_script:
   - if [ "$TRAVIS_PHP_VERSION" != "hhvm" ]; then phpenv config-rm xdebug.ini; fi
-  - if [ "$SYMFONY_VERSION" != "" ]; then composer require --no-update "symfony/dependency-injection:${SYMFONY_VERSION}"; fi
+  - if [ "$SYMFONY_DI_VERSION" != "" ]; then composer require --no-update "symfony/dependency-injection:${SYMFONY_DI_VERSION}"; fi
+  - if [ "$SYMFONY_YAML_VERSION" != "" ]; then composer require --no-update "symfony/yaml:${SYMFONY_YAML_VERSION}"; fi
   - if [ "$PHPUNIT_VERSION" != "" ]; then composer require --no-update "phpunit/phpunit:${PHPUNIT_VERSION}"; fi
   - if [ "$deps" = "low" ]; then composer update --prefer-lowest; fi
   - if [ "$deps" = "" ]; then composer install; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,9 +32,9 @@ matrix:
     - php: 5.6
       env: SYMFONY_VERSION=2.7.* PHPUNIT_VERSION=~4.0
     - php: 5.6
-      env: SYMFONY_VERSION=2.8.*@dev PHPUNIT_VERSION=~4.0
+      env: SYMFONY_VERSION=2.8.* PHPUNIT_VERSION=~4.0
     - php: 5.6
-      env: SYMFONY_VERSION=3.0.*@dev PHPUNIT_VERSION=~4.0
+      env: SYMFONY_VERSION=3.0.* PHPUNIT_VERSION=~4.0
   allow_failures:
     - php: hhvm
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,7 @@ matrix:
     - php: hhvm
 
 before_script:
+  - if [ "$TRAVIS_PHP_VERSION" != "hhvm" ]; then phpenv config-rm xdebug.ini; fi
   - if [ "$SYMFONY_VERSION" != "" ]; then composer require --no-update "symfony/dependency-injection:${SYMFONY_VERSION}"; fi
   - if [ "$PHPUNIT_VERSION" != "" ]; then composer require --no-update "phpunit/phpunit:${PHPUNIT_VERSION}"; fi
   - if [ "$deps" = "low" ]; then composer update --prefer-lowest; fi


### PR DESCRIPTION
Since Symfony 3.0, you can no longer pass the path of a YAML file to the parser (the parser will always treat the passed argument as a YAML string). Thus, for legacy versions of the DependencyInjection component an old version of the Yaml component needs to be installed.