### PR TITLE
Update Travis matrix build & bump up Composer dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,33 +15,20 @@ matrix:
   include:
     - php: 5.3
       env: deps="low"
-    - php: 5.6
-      env: SYMFONY_DI_VERSION=2.3.* PHPUNIT_VERSION=~3.7
-    - php: 5.6
-      env: SYMFONY_DI_VERSION=2.0.* SYMFONY_YAML_VERSION=2.7.* PHPUNIT_VERSION=~4.0
-    - php: 5.6
-      env: SYMFONY_DI_VERSION=2.1.* SYMFONY_YAML_VERSION=2.7.* PHPUNIT_VERSION=~4.0
-    - php: 5.6
-      env: SYMFONY_DI_VERSION=2.2.* SYMFONY_YAML_VERSION=2.7.* PHPUNIT_VERSION=~4.0
-    - php: 5.6
-      env: SYMFONY_DI_VERSION=2.3.* PHPUNIT_VERSION=~4.0
-    - php: 5.6
-      env: SYMFONY_DI_VERSION=2.4.* PHPUNIT_VERSION=~4.0
-    - php: 5.6
-      env: SYMFONY_DI_VERSION=2.6.* PHPUNIT_VERSION=~4.0
-    - php: 5.6
-      env: SYMFONY_DI_VERSION=2.7.* PHPUNIT_VERSION=~4.0
-    - php: 5.6
-      env: SYMFONY_DI_VERSION=2.8.* PHPUNIT_VERSION=~4.0
-    - php: 5.6
-      env: SYMFONY_DI_VERSION=3.0.* PHPUNIT_VERSION=~4.0
+    - php: 7.0
+      env: SYMFONY_DI_VERSION=2.3.*
+    - php: 7.0
+      env: SYMFONY_DI_VERSION=2.7.*
+    - php: 7.0
+      env: SYMFONY_DI_VERSION=2.8.*
+    - php: 7.0
+      env: SYMFONY_DI_VERSION=3.0.*
   allow_failures:
     - php: hhvm
 
 before_script:
   - if [ "$TRAVIS_PHP_VERSION" != "hhvm" ]; then phpenv config-rm xdebug.ini; fi
   - if [ "$SYMFONY_DI_VERSION" != "" ]; then composer require --no-update "symfony/dependency-injection:${SYMFONY_DI_VERSION}"; fi
-  - if [ "$SYMFONY_YAML_VERSION" != "" ]; then composer require --no-update "symfony/yaml:${SYMFONY_YAML_VERSION}"; fi
   - if [ "$PHPUNIT_VERSION" != "" ]; then composer require --no-update "phpunit/phpunit:${PHPUNIT_VERSION}"; fi
   - if [ "$deps" = "low" ]; then composer update --prefer-lowest; fi
   - if [ "$deps" = "" ]; then composer install; fi

--- a/Tests/PhpUnit/AbstractExtensionTestCaseTest.php
+++ b/Tests/PhpUnit/AbstractExtensionTestCaseTest.php
@@ -153,7 +153,7 @@ class AbstractExtensionTestCaseTest extends AbstractExtensionTestCase
     {
         $this->load();
 
-        $this->setExpectedException('\PHPUnit_Framework_ExpectationFailedException', 10);
+        $this->setExpectedException('\PHPUnit_Framework_ExpectationFailedException', '10');
 
         $this->assertContainerBuilderHasServiceDefinitionWithArgument('manual_service_id', 10, 'any value');
     }

--- a/Tests/PhpUnit/ContainerHasParameterConstraintTest.php
+++ b/Tests/PhpUnit/ContainerHasParameterConstraintTest.php
@@ -29,23 +29,17 @@ class ContainerHasParameterConstraintTest extends \PHPUnit_Framework_TestCase
 
         $parameterName = 'parameter_name';
         $parameterValue = 'some value';
-        $containerWithParameter = $this->createMockContainerWithParameters(
-            array(
-                $parameterName => $parameterValue
-            )
-        );
-
         $wrongParameterValue = 'some other value';
 
         return array(
             // the container does not have the parameter
             array($emptyContainer, $parameterName, $parameterValue, true, false),
             // the container has the parameter but the values don't match
-            array($containerWithParameter, $parameterName, $wrongParameterValue, true, false),
+            array($this->createMockContainerWithParameters(array($parameterName => $parameterValue)), $parameterName, $wrongParameterValue, true, false),
             // the container has the parameter and the value matches
-            array($containerWithParameter, $parameterName, $parameterValue, true, true),
+            array($this->createMockContainerWithParameters(array($parameterName => $parameterValue)), $parameterName, $parameterValue, true, true),
             // the container has the parameter and the value is optional
-            array($containerWithParameter, $parameterName, null, false, true),
+            array($this->createMockContainerWithParameters(array($parameterName => $parameterValue)), $parameterName, null, false, true),
         );
     }
 
@@ -56,24 +50,16 @@ class ContainerHasParameterConstraintTest extends \PHPUnit_Framework_TestCase
         $container
             ->expects($this->any())
             ->method('hasParameter')
-            ->will(
-                $this->returnCallback(
-                    function ($parameterName) use ($parameters) {
-                        return array_key_exists($parameterName, $parameters);
-                    }
-                )
-            );
+            ->willReturnCallback(function ($parameterName) use ($parameters) {
+                return array_key_exists($parameterName, $parameters);
+            });
 
         $container
             ->expects($this->any())
             ->method('getParameter')
-            ->will(
-                $this->returnCallback(
-                    function ($parameterName) use ($parameters) {
-                        return $parameters[$parameterName];
-                    }
-                )
-            );
+            ->willReturnCallback(function ($parameterName) use ($parameters) {
+                return $parameters[$parameterName];
+            });
 
         return $container;
     }

--- a/composer.json
+++ b/composer.json
@@ -13,16 +13,13 @@
         }
     ],
     "require": {
-        "matthiasnoback/symfony-config-test": "0.*|~1.0",
-        "symfony/dependency-injection": "^2.0.5|~3.0",
-        "symfony/config": "^2.0.5|~3.0",
-        "sebastian/exporter": "~1"
+        "matthiasnoback/symfony-config-test": "^1.0|^2.0",
+        "phpunit/phpunit": "^4.0|^5.0",
+        "symfony/dependency-injection": "^2.3|^3.0",
+        "symfony/config": "^2.3|^3.0",
+        "symfony/yaml": "^2.7|^3.0",
+        "sebastian/exporter": "^1.0"
     },
-    "require-dev": {
-        "phpunit/phpunit": "~3.0|~4.0"
-    },
-    "minimum-stability": "dev",
-    "prefer-stable": true,
     "autoload": {
         "psr-4" : { "Matthias\\SymfonyDependencyInjectionTest\\" : "" }
     }


### PR DESCRIPTION
Similar to matthiasnoback/SymfonyConfigTest#32 - drops unsupported Symfony versions and PhpUnit `3.7`. Moreover, drops support for SymfonyConfigTest `0.*` and allows for `2.0` to be installed.