### PR TITLE
Move phpunit back to the require-dev section

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,11 +14,13 @@
     ],
     "require": {
         "matthiasnoback/symfony-config-test": "^1.0|^2.0",
-        "phpunit/phpunit": "^4.0|^5.0",
         "symfony/dependency-injection": "^2.3|^3.0",
         "symfony/config": "^2.3|^3.0",
         "symfony/yaml": "^2.7|^3.0",
         "sebastian/exporter": "^1.0"
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^4.0|^5.0"
     },
     "autoload": {
         "psr-4" : { "Matthias\\SymfonyDependencyInjectionTest\\" : "" }


### PR DESCRIPTION
It was sneakily moved back to require in #61, without any explanation.
Also see #47, #28.