### PR TITLE
Use namespaced test case

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,6 @@ sudo: false
 language: php
 
 php:
-  - 5.3
-  - 5.4
-  - 5.5
   - 5.6
   - 7.0
   - hhvm
@@ -13,7 +10,7 @@ php:
 matrix:
   fast_finish: true
   include:
-    - php: 5.3
+    - php: 5.6
       env: deps="low"
     - php: 7.0
       env: SYMFONY_DI_VERSION=2.3.*

--- a/PhpUnit/AbstractContainerBuilderTestCase.php
+++ b/PhpUnit/AbstractContainerBuilderTestCase.php
@@ -2,10 +2,11 @@
 
 namespace Matthias\SymfonyDependencyInjectionTest\PhpUnit;
 
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 
-abstract class AbstractContainerBuilderTestCase extends \PHPUnit_Framework_TestCase
+abstract class AbstractContainerBuilderTestCase extends TestCase
 {
     /**
      * @var ContainerBuilder

--- a/PhpUnit/AbstractExtensionConfigurationTestCase.php
+++ b/PhpUnit/AbstractExtensionConfigurationTestCase.php
@@ -5,10 +5,11 @@ namespace Matthias\SymfonyDependencyInjectionTest\PhpUnit;
 use Matthias\SymfonyConfigTest\PhpUnit\ProcessedConfigurationEqualsConstraint;
 use Matthias\SymfonyDependencyInjectionTest\Loader\ExtensionConfigurationBuilder;
 use Matthias\SymfonyDependencyInjectionTest\Loader\LoaderFactory;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
 
-abstract class AbstractExtensionConfigurationTestCase extends \PHPUnit_Framework_TestCase
+abstract class AbstractExtensionConfigurationTestCase extends TestCase
 {
     /**
      * Return an instance of the container extension that you are testing.

--- a/Tests/Loader/LoaderFactoryTest.php
+++ b/Tests/Loader/LoaderFactoryTest.php
@@ -3,8 +3,9 @@
 namespace Matthias\SymfonyDependencyInjectionTest\Tests\Loader;
 
 use Matthias\SymfonyDependencyInjectionTest\Loader\LoaderFactory;
+use PHPUnit\Framework\TestCase;
 
-class LoaderFactoryTest extends \PHPUnit_Framework_TestCase
+class LoaderFactoryTest extends TestCase
 {
     /**
      * @test

--- a/Tests/PhpUnit/ContainerBuilderHasAliasConstraintTest.php
+++ b/Tests/PhpUnit/ContainerBuilderHasAliasConstraintTest.php
@@ -3,9 +3,10 @@
 namespace Matthias\SymfonyDependencyInjectionTest\Tests\PhpUnit;
 
 use Matthias\SymfonyDependencyInjectionTest\PhpUnit\ContainerBuilderHasAliasConstraint;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
-class ContainerBuilderHasAliasConstraintTest extends \PHPUnit_Framework_TestCase
+class ContainerBuilderHasAliasConstraintTest extends TestCase
 {
     /**
      * @test

--- a/Tests/PhpUnit/ContainerBuilderHasServiceDefinitionConstraintTest.php
+++ b/Tests/PhpUnit/ContainerBuilderHasServiceDefinitionConstraintTest.php
@@ -3,10 +3,11 @@
 namespace Matthias\SymfonyDependencyInjectionTest\Tests\PhpUnit\DependencyInjection;
 
 use Matthias\SymfonyDependencyInjectionTest\PhpUnit\ContainerBuilderHasServiceDefinitionConstraint;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 
-class ContainerBuilderHasServiceDefinitionConstraintTest extends \PHPUnit_Framework_TestCase
+class ContainerBuilderHasServiceDefinitionConstraintTest extends TestCase
 {
     /**
      * @test

--- a/Tests/PhpUnit/ContainerBuilderHasSyntheticServiceConstraintTest.php
+++ b/Tests/PhpUnit/ContainerBuilderHasSyntheticServiceConstraintTest.php
@@ -3,10 +3,11 @@
 namespace Matthias\SymfonyDependencyInjectionTest\Tests\PhpUnit\DependencyInjection;
 
 use Matthias\SymfonyDependencyInjectionTest\PhpUnit\ContainerBuilderHasSyntheticServiceConstraint;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 
-class ContainerBuilderHasSyntheticServiceConstraintTest extends \PHPUnit_Framework_TestCase
+class ContainerBuilderHasSyntheticServiceConstraintTest extends TestCase
 {
     /**
      * @var ContainerBuilder

--- a/Tests/PhpUnit/ContainerHasParameterConstraintTest.php
+++ b/Tests/PhpUnit/ContainerHasParameterConstraintTest.php
@@ -3,9 +3,10 @@
 namespace Matthias\SymfonyDependencyInjectionTest\Tests\PhpUnit\DependencyInjection;
 
 use Matthias\SymfonyDependencyInjectionTest\PhpUnit\ContainerHasParameterConstraint;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
-class ContainerHasParameterConstraintTest extends \PHPUnit_Framework_TestCase
+class ContainerHasParameterConstraintTest extends TestCase
 {
     /**
      * @test

--- a/Tests/PhpUnit/DefinitionHasArgumentConstraintTest.php
+++ b/Tests/PhpUnit/DefinitionHasArgumentConstraintTest.php
@@ -3,10 +3,11 @@
 namespace Matthias\SymfonyDependencyInjectionTest\Tests\PhpUnit\DependencyInjection;
 
 use Matthias\SymfonyDependencyInjectionTest\PhpUnit\DefinitionHasArgumentConstraint;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\DefinitionDecorator;
 
-class DefinitionHasArgumentConstraintTest extends \PHPUnit_Framework_TestCase
+class DefinitionHasArgumentConstraintTest extends TestCase
 {
     /**
      * @test

--- a/Tests/PhpUnit/DefinitionHasMethodCallConstraintTest.php
+++ b/Tests/PhpUnit/DefinitionHasMethodCallConstraintTest.php
@@ -3,9 +3,10 @@
 namespace Matthias\SymfonyDependencyInjectionTest\Tests\PhpUnit\DependencyInjection;
 
 use Matthias\SymfonyDependencyInjectionTest\PhpUnit\DefinitionHasMethodCallConstraint;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\Definition;
 
-class DefinitionHasMethodCallConstraintTest extends \PHPUnit_Framework_TestCase
+class DefinitionHasMethodCallConstraintTest extends TestCase
 {
     /**
      * @test

--- a/Tests/PhpUnit/DefinitionHasTagConstraintTest.php
+++ b/Tests/PhpUnit/DefinitionHasTagConstraintTest.php
@@ -3,9 +3,10 @@
 namespace Matthias\SymfonyDependencyInjectionTest\Tests\PhpUnit\DependencyInjection;
 
 use Matthias\SymfonyDependencyInjectionTest\PhpUnit\DefinitionHasTagConstraint;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\Definition;
 
-class DefinitionHasTagConstraintTest extends \PHPUnit_Framework_TestCase
+class DefinitionHasTagConstraintTest extends TestCase
 {
     /**
      * @test

--- a/Tests/PhpUnit/DefinitionIsChildOfConstraintTest.php
+++ b/Tests/PhpUnit/DefinitionIsChildOfConstraintTest.php
@@ -4,10 +4,11 @@
 namespace Matthias\DependencyInjectionTests\Test\DependencyInjection;
 
 use Matthias\SymfonyDependencyInjectionTest\PhpUnit\DefinitionIsChildOfConstraint;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\DefinitionDecorator;
 
-class DefinitionIsChildOfConstraintTest extends \PHPUnit_Framework_TestCase
+class DefinitionIsChildOfConstraintTest extends TestCase
 {
     /**
      * @test

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "sebastian/exporter": "^1.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.0|^5.0"
+        "phpunit/phpunit": "^5.4.3"
     },
     "autoload": {
         "psr-4" : { "Matthias\\SymfonyDependencyInjectionTest\\" : "" }


### PR DESCRIPTION
This implies dropping phpunit 4, and is therefore major, because phpunit
is in the require-dev section of the Composer manifest, which means it
is not an explicit dependency of this package.
Refs #66