### PR TITLE
Move PHPUnit to require instead of require-dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,13 +14,11 @@
     ],
     "require": {
         "php": "^7.0",
+        "phpunit/phpunit": "^6.0",
         "matthiasnoback/symfony-config-test": "^3.0",
         "symfony/dependency-injection": "^2.3|^3.0",
         "symfony/config": "^2.3|^3.0",
         "symfony/yaml": "^2.7|^3.0"
-    },
-    "require-dev": {
-        "phpunit/phpunit": "^6.0"
     },
     "autoload": {
         "psr-4" : { "Matthias\\SymfonyDependencyInjectionTest\\" : "" }


### PR DESCRIPTION
PHPUnit should be in `require` section since this library actually depends on `phpunit/phpunit` for it to work, rather than just use `phpunit/phpunit` when developing the lib.

PHPUnit not being in `require` section, makes it possible to install PHPUnit 5 with version 2 of this lib, which is wrong, since Composer does not recurse dev dependencies.